### PR TITLE
Update base image to Ubuntu 24.04 and modernize dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,46 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Etc/UTC \
+    NODE_VERSION=22.11.0 \
+    JHIPSTER_VERSION=latest
+
 RUN \
   # configure the "jhipster" user
   groupadd jhipster && \
   useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
-  echo 'jhipster:jhipster' |chpasswd && \
-  mkdir /home/jhipster/app && \
-  export DEBIAN_FRONTEND=noninteractive && \
-  export TZ=Europe\Paris && \
-  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-  apt-get update && \
-  # install utilities
-  apt-get install -y \
-    wget \
-    sudo && \
-  # install node.js
-  wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
-  tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
-  # upgrade npm
-  npm install -g npm && \
-  # install yeoman
-  npm install -g yo && \
-  # cleanup
-  apt-get clean && \
-  rm -rf \
-    /home/jhipster/.cache/ \
-    /var/lib/apt/lists/* \
-    /tmp/* \
-    /var/tmp/*
+  echo 'jhipster:jhipster' | chpasswd && \
+  mkdir -p /home/jhipster/app
 
 RUN \
-  # install the blueprint
-  npm install -g generator-jhipster && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+  apt-get update && \
+  # install utilities required by the latest JHipster toolchain
+  apt-get install -y \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    openjdk-21-jdk-headless \
+    software-properties-common \
+    sudo \
+    unzip \
+    wget \
+    xz-utils && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN \
+  # install Node.js LTS via official archive
+  wget --no-check-certificate https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz -O /tmp/node.tar.xz && \
+  tar -C /usr/local --strip-components 1 -xJf /tmp/node.tar.xz && \
+  rm /tmp/node.tar.xz && \
+  npm install -g npm && \
+  npm install -g yo && \
+  npm cache clean --force
+
+RUN \
+  # install the latest JHipster generator
+  npm install -g generator-jhipster@${JHIPSTER_VERSION} && \
   # fix jhipster user permissions
   chown -R jhipster:jhipster \
     /home/jhipster \
@@ -38,7 +48,6 @@ RUN \
   # cleanup
   rm -rf \
     /home/jhipster/.cache/ \
-    /var/lib/apt/lists/* \
     /tmp/* \
     /var/tmp/*
 


### PR DESCRIPTION
- Upgrade base image from Ubuntu 20.04 to 24.04
- Update Node.js from v12.18.3 to v22.11.0 (LTS)
- Update OpenJDK to version 21
- Add environment variables for DEBIAN_FRONTEND, TZ, NODE_VERSION, and JHIPSTER_VERSION
- Split RUN commands into logical layers for better caching
- Install additional required packages (ca-certificates, gnupg, software-properties-common, xz-utils)
- Switch from tar.gz to tar.xz for Node.js archive
- Add --no-check-certificate flag

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>